### PR TITLE
Fix prnull

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -32,13 +32,13 @@ jobs:
           mkdocs build -f mkdocs.yml --verbose --clean
 
       - name: Change directory structure for PR
-        if : steps.set_env.outputs.PULL_NUMBER != null
+        if: steps.set_env.outputs.PULL_NUMBER != 'null'
         run: |
           mkdir -p public/pr-check/pr${{ steps.set_env.outputs.PULL_NUMBER }}
           mv site public/pr-check/pr${{ steps.set_env.outputs.PULL_NUMBER }}/
 
       - name: Change directory structure for main
-        if : steps.set_env.outputs.PULL_NUMBER == null
+        if: steps.set_env.outputs.PULL_NUMBER == 'null'
         run: |
           mkdir -p public/pr-check/main
           mv site public/pr-check/main/


### PR DESCRIPTION
## What kinds of PR

- [ ] New feature
- [ ] Improve feature
- [x] Bug fix

## What is this PR

No `mkdocs site` for `main` branch is not generated.
https://tier4.github.io/obstacle_stop_planner_refine/pr-check/
![image](https://user-images.githubusercontent.com/31987104/113724796-ad322800-972d-11eb-8888-0e502260199b.png)

It's probably because of comparing `'null'` and `null`.
![image](https://user-images.githubusercontent.com/31987104/113724589-75c37b80-972d-11eb-967e-d1bdaec0b466.png)

## How to check this PR

Please check after merge.